### PR TITLE
Conserta migração de notícias para protestos

### DIFF
--- a/mapcon/pages/api/mapcon/_helper.ts
+++ b/mapcon/pages/api/mapcon/_helper.ts
@@ -15,21 +15,20 @@ function PrettyOBJ(obj: object, name: string) {
     return prettyObj;
 }
 
-function LogRequest(filename, req: NextApiRequest, session: Session) {
+function LogRequest(filename, req: NextApiRequest, session: Session | Object) {
     const pathSeparator = process.platform === 'win32' ? '\\' : '/';
     const pathParts = filename.split(pathSeparator);
     const lastDir = pathParts[pathParts.length - 2];
     const fileName = pathParts[pathParts.length - 1];
     const queryString = PrettyOBJ(req.query, 'Query');
     const bodyString = PrettyOBJ(req.body, 'Body');
-    const authorString = PrettyOBJ(session.user, 'Author');
+    const authorString = session && 'user' in session ? PrettyOBJ((session as Session).user, 'Author') : PrettyOBJ({}, 'Author');
     const date = new Date();
     console.debug(`\x1b[92mReceived request:\x1b[0m ${date.toLocaleDateString()+" "+date.toLocaleTimeString()}
-        \x1b[93mMethod:\x1b[0m ${req.method}
+        \x1b[93mMethod:\x1b[0m ${req.method} \x1b[91mat file:\x1b[0m \x1b[4m${lastDir}/${fileName}\x1b[0m
         ${bodyString}
         ${queryString}
-        ${authorString}
-        \x1b[93mAt file:\x1b[0m ${lastDir}/${fileName}`
+        ${authorString}`
     );
 }
 

--- a/mapcon/pages/api/mapcon/migra.ts
+++ b/mapcon/pages/api/mapcon/migra.ts
@@ -1,14 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { getSession } from 'next-auth/react';
+import { getServerSession } from "next-auth"
 import db from "../../../lib/back/db";
 import { v1 as uuidv1 } from "uuid";
 import { exec } from "child_process";
 import { LogRequest } from './_helper';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  const session = await getSession({ req });
+  const session = await getServerSession(req, res, { /* options */ });
   if (session) {
-    LogRequest(__filename, req, session);
+    LogRequest(__filename, req, req.body);
     if (!req.body.is_protesto) {
       await db("crawling.crawling_news")
         .where({ url: req.body.url })
@@ -37,7 +37,6 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
       if (typeof req.body.existente == "number") {
         // Vincula com um protesto já existente
-
         // Adicionar fonte
         await db("fonte").insert({
           fonte_protesto_num_seq_fonte_protesto: 22,
@@ -80,5 +79,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     }
     
     res.status(200).json({ ok: "Migrou" });
+  } else {
+    res.status(401).json({ error: "Não autorizado" });
   }
 };

--- a/mapcon/pages/mapcon/noticiasrastreadas/index.jsx
+++ b/mapcon/pages/mapcon/noticiasrastreadas/index.jsx
@@ -231,9 +231,15 @@ function MigraNoticiaForm({ showForm, closeForm }) {
     setSending(true);
     dados.url = url;
     dados.data = moment(dados.data).format("yyyy-MM-DD");
-
+    const session = await getSession();
     await axios
-      .post(`/api/mapcon/migra`, dados)
+      .post(`/api/mapcon/migra`, {
+        ...dados,
+        user: {
+          id: session.user.id,
+          perfil: session.user.perfil
+        }
+      })
       .then(() => setSending(false))
       .catch(() => setSending(false));
     closeForm(true);


### PR DESCRIPTION
bugfix: Fixed a bug where the session wasn't being retrieved on the client side when using the POST method, which prevented the migration of news to protests.

feat: Improved logging to show the request's method and the file of origin on the same stylized line.

Fixes #13 