### PR TITLE
Ajustes para publicação no ambiente da AWS

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# valores usados para o deploy
+PLATFORM=linux/arm64
+ECR_REPO_BASE=deaau-mapcon
+ECR_URI=279634266618.dkr.ecr.sa-east-1.amazonaws.com
+NODE_VERSION=18

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Usa a versão mais recente, caso não seja especificada
+ARG NODE_VERSION=latest
+
+# Usa a imagem leve do Node.js
+FROM node:${NODE_VERSION}
+
+# Copia os arquivos essenciais primeiro
+COPY mapcon /app
+
+# definir o ponto de entrada do contêiner
+#ENTRYPOINT [ "" ]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,39 @@
+name: mapcon-ct
+
+services:
+  postgres:
+    container_name: postgresql
+    image: postgres:16.6
+    environment:
+      POSTGRES_DB: mapcon
+      POSTGRES_USER: mapcon
+      POSTGRES_PASSWORD: mapcon
+    ports:
+      - "5432:5432"
+
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - "~/docker/volumes/keycloak/postgresql:/var/lib/postgresql"
+      - "~/docker/volumes/keycloak/postgresql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d"
+
+  mapcon:
+    container_name: deaau-mapcon
+    image: "${COMPOSE_PROJECT_NAME}:node-${NODE_VERSION}"
+    build:
+      context: .
+      args:
+        PLATFORM: ${PLATFORM}
+        PROJECT: ${COMPOSE_PROJECT_NAME}
+        NODE_VERSION: ${NODE_VERSION}
+    ports:
+      - "8080:8080"
+    env_file:
+      - path: env/${COMPOSE_PROJECT_NAME}.env
+        required: true
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Carrega a imagem no ECR
+# A imagem preferencial usada no ECS será aquela com tag latest
+
+PROJECT=$1
+
+if [ -z ${PROJECT} ]; then
+    echo "Uso: deploy.sh <nome_do_projeto>"
+    echo "Erro: Nome do projeto não informado"
+    exit 1
+fi
+
+PROJECT_ENV=env/${PROJECT}.env
+
+if [ ! -r ${PROJECT_ENV} ]; then
+    echo "Erro: Arquivo ${PROJECT_ENV} não existe ou não é legível"
+    exit 2
+fi
+
+source .env
+source ${PROJECT_ENV}
+
+export ECR_REPO=${ECR_REPO_BASE}
+ECR_REPO_URI=${ECR_URI}/${ECR_REPO}
+TAGS="node-${NODE_VERSION} latest"
+
+# algumas variáveis de ambiente precisam ser passadas ao compose
+export NODE_VERSION
+docker compose -p ${PROJECT} build
+
+# aplica os tags à imagem
+for t in $TAGS; do
+    docker tag ${ECR_REPO}:node-${NODE_VERSION} ${ECR_REPO_URI}:${t}
+done
+
+# upload da imagem no ECR
+docker push --all-tags ${ECR_REPO_URI}

--- a/env/deaau-mapcon.env
+++ b/env/deaau-mapcon.env
@@ -1,0 +1,4 @@
+# Variáveis de ambiente necessárias para a execução da aplicação
+# Os valores definidos aqui são usados apenas para execução local
+# No ambiente do ECS as variáveis são obtidas do Secrets Manager e injetadas
+# no contêiner automaticamente


### PR DESCRIPTION
Foram incluídas configurações e scripts para preparar o contêiner para publicação no ambiente da AWS.

Para criar a imagem:
`$ docker compose -p deaau-mapcon build`

Deve ser possível executar a aplicação executando:
`$ docker compose -p deaau-mapcon up -d`

Para publicar a imagem:
`$ ./deploy.sh deaau-mapcon`

Atentar para o seguinte:

- Como não há informações suficientes, foram incluídos apenas esqueletos de arquivos para a devida complementação.
- É necessário ajustar o Dockerfile para que a imagem seja criada corretamente, eventualmente com os comandos para instalação dos pacotes necessários
- Avaliar a atualização do Node para a versão 23. A versão 18 está muito desatualizada
- Ainda não foi concedida permissão de push, portanto, a última fase do deploy.sh falhará. Assim que o build e up estiverem corretos, daremos continuidade com a concessão das permissões necessárias no ECS, de acordo com a solução mais adequada.