### PR TITLE
Ajustes no fluxo de criação da imagem e execução do contêiner

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,8 @@
 name: mapcon-ct
 
 services:
-  postgres:
-    container_name: postgresql
+  deaau-mapcon-postgresql:
+    container_name: deaau-mapcon-postgresql
     image: postgres:16.6
     environment:
       POSTGRES_DB: mapcon
@@ -17,8 +17,7 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-      - "~/docker/volumes/keycloak/postgresql:/var/lib/postgresql"
-      - "~/docker/volumes/keycloak/postgresql/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d"
+      - deaau-mapcon-postgresql:/var/lib/postgresql"
 
   mapcon:
     container_name: deaau-mapcon
@@ -35,7 +34,10 @@ services:
       - path: env/${COMPOSE_PROJECT_NAME}.env
         required: true
     depends_on:
-      postgres:
+      deaau-mapcon-postgresql:
         condition: service_healthy
     command: ["/bin/bash", "./entrypoint.sh", "production"]
     # command: ["/bin/sh", "-c", "while true; do sleep 1; done"]
+
+volumes:
+  deaau-mapcon-postgresql:

--- a/env/deaau-mapcon.env
+++ b/env/deaau-mapcon.env
@@ -2,3 +2,10 @@
 # Os valores definidos aqui são usados apenas para execução local
 # No ambiente do ECS as variáveis são obtidas do Secrets Manager e injetadas
 # no contêiner automaticamente
+DB_HOST=deaau-mapcon-postgresql
+DB_PORT=5432
+DB_NAME=mapcon
+DB_SCHEMA=public
+DB_USER=mapcon
+DB_PASSWORD=mapcon
+DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?schema=${DB_SCHEMA}


### PR DESCRIPTION
Foram incluídas configurações e scripts para preparar o contêiner para publicação no ambiente da AWS.

Após o ajuste de algumas variáveis de ambiente a imagem foi criada com sucesso executando:
`$ docker compose -p deaau-mapcon build`

Ajustando a variável de ambiente DATABASE_URL o banco de dados foi inicializado corretamente, mas a execução da aplicação apresentou erro ao executar: 
`$ docker compose -p deaau-mapcon up`

Os erros reportados foram os seguintes:

```
deaau-mapcon             |  ✓ Starting...
deaau-mapcon             | Error: Could not find a production build in the '.next' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id
deaau-mapcon             |     at setupFsCheck (/app/node_modules/next/dist/server/lib/router-utils/filesystem.js:151:19)
deaau-mapcon             |     at async initialize (/app/node_modules/next/dist/server/lib/router-server.js:62:23)
deaau-mapcon             |     at async Server.<anonymous> (/app/node_modules/next/dist/server/lib/start-server.js:249:36)
deaau-mapcon exited with code 1
```